### PR TITLE
Ruin regex bugfix

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@
             <button class="toggle-button-mods" onclick="toggleModButton(this, '^res')">
                 <img src="static/images/Resistant_Monsters.png" alt="Resistant Monsters" height="38px" width="38px">
                 Resistant Monsters</button>
-            <button class="toggle-button-mods" onclick="toggleModButton(this, 'ru')">
+            <button class="toggle-button-mods" onclick="toggleModButton(this, '^ru')">
                 <img src="static/images/Ruin.png" alt="Ruin" height="38px" width="38px">
                 Ruin</button>
         </div>


### PR DESCRIPTION
Changed regex for ruin from "ru" to "^ru" to avoid matching stormcaller runes.